### PR TITLE
Make starter actually work and update README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+roles/osxc.*

--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ You can reach our (temporarily not updated and old) [website](http://osxc.github
 
 > **Warning:**: All of this is subject to change, just be sure you're able to reach this page to see the latest instructions when it'll be updated. Don't worry though, we will not change brutally the structure of your current repo (not like we did with legacy). All we are going to do is add a CLI tool.
 
+> **Additional Note:** If you're installing system-wide `sudo ansible-galaxy install -r requirements.yml` otherwise edit `ansible.cfg` and comment out `roles_path:./roles` to install the roles in your osxc.starter fork before running **Step 5**.
+
 1. Be sure to have the XCode Command-Line tools installed: `xcode-select --install`
-2. [Fork this repo](https://github.com/osxc/starter/fork)
-3. Clone your forked repo anywhere you want on your machine: `git clone git@github.com:<myname>/starter.git; mv starter osxc; cd osxc`
-4. Setup your system with `sudo easy_install pip; sudo pip install ansible`
+2. Manually install Ansible 1.8 with ``git clone https://github.com/ansible/ansible.git ~/src/github.com/ansible/ansible; cd ~/src/github.com/ansible/ansible; sudo make install``
+3. While that's happening [Fork this repo](https://github.com/osxc/starter/fork) and then clone your fork anywhere you want on your machine: `git clone git@github.com:<yourname>/starter.git; mv starter osxc; cd osxc`
+4. Take a quick look at `configuarion.yml` and `installation.yml` customizing to your liking.
 5. Start osxc with `ansible-galaxy install -r requirements.yml && ansible-playbook desktop.yml`
 
 At the end, you'll only need to repeat step 5.
 
-Now you're ready to tweak the configuration we gave you. Have fun ! (You may want to read the [Ansible documentation](http://docs.ansible.com/index.html) in this case ...)
+Now you're ready to further tweak the configuration we gave you. Have fun ! (You may want to read the [Ansible documentation](http://docs.ansible.com/index.html) in this case ...)
 
 ## Learn More
 

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 hostfile = ./inventory
+roles_path = ./roles

--- a/configuration.yml
+++ b/configuration.yml
@@ -2,10 +2,10 @@
 # Configure your freshly installed software
 - hosts: all
   roles:
-  - role: repository
+  - role: osxc.repository
     clone_url: https://github.com/robbyrussell/oh-my-zsh.git
     dest: /Users/{{ ansible_user_id }}/.oh-my-zsh
-  - role: repository
+  - role: osxc.repository
     clone_url: https://github.com/square/maximum-awesome.git
     dest: /Users/{{ ansible_user_id }}/.vim
     links:
@@ -15,7 +15,7 @@
       dest: /Users/{{ ansible_user_id }}/.vimrc.bundles
     - src: tmux.conf
       dest: /Users/{{ ansible_user_id }}/.tmux.conf
-  - role: repository
+  - role: osxc.repository
     clone_url: https://github.com/gmarik/vundle.git
     dest: /Users/{{ ansible_user_id }}/.vim/bundle/vundle
   post_tasks:

--- a/install.yml
+++ b/install.yml
@@ -2,7 +2,7 @@
 # Here we describe every software we may want to install
 - hosts: all
   roles:
-  - role: packages
+  - role: osxc.packages
     brew_taps:
     - caskroom/fonts
     brew_packages:

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,4 +3,4 @@
 - src: osxc.common-env
 - src: osxc.homebrew
 - src: osxc.packages
-- src: repository
+- src: osxc.repository


### PR DESCRIPTION
Updated README.md with working, but not finished, install directions.
Added .gitignore to not store the osxc.\* roles from galaxy and .DS_Store cruft.
Made default behavior for a single-user install with ansible.cfg's roles_path = ./roles
Updated configuration.yml and install.yml to handle osxc.\* role names.
Fixed small issue with requirements.yml using repository instead of osxc.repository.
